### PR TITLE
Fix: Changed test video URL to Youtube Music version. 

### DIFF
--- a/copy_playlists.py
+++ b/copy_playlists.py
@@ -692,7 +692,7 @@ def check_api_quota():
         if not test_playlist_id:
             return False, "Failed to create test playlist (quota or headers issue)"
 
-        test_video_id = 'dQw4w9WgXcQ'
+        test_video_id = 'lYBUbBu4W08'
         try:
             ytmusic.add_playlist_items(test_playlist_id, [test_video_id])
         except Exception as e:


### PR DESCRIPTION
#7 

check_api_quota was using the video ID for the main Rick Astley - Never Gunna Give You Up, but Youtube Music appears to auto-change the video ID to the audio release.

Since the video ID changed, it would not recognize the song as the test, and would automatically fail.

Fixed by changing the video ID to the returned video.

Rick got me once again.